### PR TITLE
New part of the plotgenerator to create custom plots

### DIFF
--- a/customplot_templates/dashboard_summary_template.py
+++ b/customplot_templates/dashboard_summary_template.py
@@ -19,7 +19,6 @@ import numpy as np
 custom_plot_dict = {}
 
 custom_plot_dict["title"] = "Metric [@]chosen_quantity_name[@] for [@]tier_name[@]"
-custom_plot_dict["search_for_title_placeholders"] = True
 
 custom_plot_dict["additional_hlines"] = []
 
@@ -40,6 +39,3 @@ y_tick_label_list = ["other", "error", "warning", "ok"]
 for color, y_tick_label, statusnumber in zip(color_list, y_tick_label_list, np.arange(1,5)):
     custom_plot_dict["additional_hlines"].append({"y_value" : statusnumber, "color" : color, "linewidth" : 8})
     custom_plot_dict["custom_y_ticks"].append({"y_value" : statusnumber, "color" : color, "y_tick_label" : y_tick_label})
-
-
-

--- a/customplot_templates/dashboard_summary_template.py
+++ b/customplot_templates/dashboard_summary_template.py
@@ -14,6 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import numpy as np
+
 custom_plot_dict = {}
 
 custom_plot_dict["title"] = "Dashboard Summary: Metric {METRIC} for {SITE}"
@@ -33,7 +35,7 @@ custom_plot_dict["x_label"] = "UTC Time"
 color_list = ["gray", "red", "orange", "green"]
 y_tick_label_list = ["other", "error", "warning", "ok"]
 
-for color, y_label, statusnumber in zip(color_list, y_tick_label_list, np.arange(1,5)):
+for color, y_tick_label, statusnumber in zip(color_list, y_tick_label_list, np.arange(1,5)):
     custom_plot_dict["additional_hlines"].append({"y_value" : statusnumber, "color" : color, "linewidth" : 8})
     custom_plot_dict["custom_y_ticks"].append({"y_value" : statusnumber, "color" : color, "y_tick_label" : y_tick_label})
 

--- a/customplot_templates/dashboard_summary_template.py
+++ b/customplot_templates/dashboard_summary_template.py
@@ -32,6 +32,8 @@ custom_plot_dict["plot_position_changes"] = {"x0_shift":0.,"y0_shift": 0.3, "x_w
 custom_plot_dict["x_is_time"] = True
 custom_plot_dict["x_label"] = "UTC Time"
 
+custom_plot_dict["curve_style"] = {"color" : "white", "marker" : "o", "linestyle" : "None"}
+
 color_list = ["gray", "red", "orange", "green"]
 y_tick_label_list = ["other", "error", "warning", "ok"]
 

--- a/customplot_templates/dashboard_summary_template.py
+++ b/customplot_templates/dashboard_summary_template.py
@@ -14,7 +14,28 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-
 custom_plot_dict = {}
-custom_plot_dict["title"] = "Dashboard Summary"
+
+custom_plot_dict["title"] = "Dashboard Summary: Metric {METRIC} for {SITE}"
+custom_plot_dict["search_for_title_placeholders"] = True
+
+custom_plot_dict["additional_hlines"] = []
+
+custom_plot_dict["y_lims"] = [0.5,4.5]
+custom_plot_dict["y_label"] = ""
+custom_plot_dict["custom_y_ticks"] = []
+
+custom_plot_dict["plot_position_changes"] = {"x0_shift":0.,"y0_shift": 0.3, "x_width_change": 0.0, "y_height_change":-0.3}
+
+custom_plot_dict["x_is_time"] = True
+custom_plot_dict["x_label"] = "UTC Time"
+
+color_list = ["gray", "red", "orange", "green"]
+y_tick_label_list = ["other", "error", "warning", "ok"]
+
+for color, y_label, statusnumber in zip(color_list, y_tick_label_list, np.arange(1,5)):
+    custom_plot_dict["additional_hlines"].append({"y_value" : statusnumber, "color" : color, "linewidth" : 8})
+    custom_plot_dict["custom_y_ticks"].append({"y_value" : statusnumber, "color" : color, "y_tick_label" : y_tick_label})
+
+
 

--- a/customplot_templates/dashboard_summary_template.py
+++ b/customplot_templates/dashboard_summary_template.py
@@ -18,7 +18,7 @@ import numpy as np
 
 custom_plot_dict = {}
 
-custom_plot_dict["title"] = "Dashboard Summary: Metric {METRIC} for {SITE}"
+custom_plot_dict["title"] = "Metric [@]chosen_quantity_name[@] for [@]tier_name[@]"
 custom_plot_dict["search_for_title_placeholders"] = True
 
 custom_plot_dict["additional_hlines"] = []

--- a/customplot_templates/dashboard_summary_template.py
+++ b/customplot_templates/dashboard_summary_template.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012 Institut für Experimentelle Kernphysik - Karlsruher Institut für Technologie
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+custom_plot_dict = {}
+custom_plot_dict["title"] = "Dashboard Summary"
+

--- a/defaultconfig/happyface.cfg
+++ b/defaultconfig/happyface.cfg
@@ -15,6 +15,7 @@ tmp_dir = %(static_dir)s/tmp
 tmp_url = %(static_dir)s/tmp
 
 hf_template_dir = templates
+customplot_template_dir = customplot_templates
 module_template_dir = modules/templates
 template_cache_dir = mako_cache
 

--- a/hf/plotgenerator/__init__.py
+++ b/hf/plotgenerator/__init__.py
@@ -2,6 +2,7 @@ import hf
 import logging
 from dispatcher import Dispatcher
 from timeseries import timeseriesPlot, getTimeseriesUrl, getTimeseriesPlotConfig
+from customplot import customPlot, getCustomPlotUrl
 
 logger = logging.getLogger(__name__)
 

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -104,7 +104,7 @@ def customPlot(**kwargs):
     if custom_plot_dict["search_for_title_placeholders"]:
         placeholder_list = re.findall(r"\[\@\](.*?)\[\@\]", custom_plot_dict["title"])
         for placeholder in placeholder_list:
-            for key,value in kwargs.interitems():
+            for key,value in kwargs.iteritems():
                 if key == placeholder:
                     title = title.replace("[@]"+placeholder+"[@]",value)
                     break

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -77,10 +77,8 @@ def __getDataPoints(module_instance_name,subtable_name,x_name,y_name,quantity_co
         .where(subtable.c.parent_id == mod_table.c.id) \
         .where(mod_table.c.run_id == run_id ) \
         .where(getattr(subtable.c, quantity_column_name) == chosen_quantity_name)
-    logger.error(data_point_query)
     result = data_point_query.execute()
     source_data = result.fetchall()
-    logger.error(source_data)
     return source_data
 
 def customPlot(**kwargs):
@@ -111,18 +109,20 @@ def customPlot(**kwargs):
     # modifying y axis
     ax.set_ylim(custom_plot_dict["y_lims"][0],custom_plot_dict["y_lims"][1])
     ax.set_ylabel(custom_plot_dict["y_label"])
-    
-    custom_y_ticks = [d["y_value"] for d in custom_plot_dict["custom_y_ticks"]]
-    custom_y_tick_labels = [d["y_tick_label"] for d in custom_plot_dict["custom_y_ticks"]]
-    custom_y_tick_colors = [d["color"] for d in custom_plot_dict["custom_y_ticks"]]
-    
-    ax.set_yticks(custom_y_ticks)
-    ax.set_yticklabels(custom_y_tick_labels)
-    
-    tick_labels = ax.get_yticklabels()
-    for color,label in zip(custom_y_tick_colors,tick_labels):
-        label.set_color(color)
-        label.set_weight('bold')
+   
+    if len(custom_plot_dict["custom_y_ticks"]) > 0:
+        
+        custom_y_ticks = [d["y_value"] for d in custom_plot_dict["custom_y_ticks"]]
+        custom_y_tick_labels = [d["y_tick_label"] for d in custom_plot_dict["custom_y_ticks"]]
+        custom_y_tick_colors = [d["color"] for d in custom_plot_dict["custom_y_ticks"]]
+        
+        ax.set_yticks(custom_y_ticks)
+        ax.set_yticklabels(custom_y_tick_labels)
+        
+        tick_labels = ax.get_yticklabels()
+        for color,label in zip(custom_y_tick_colors,tick_labels):
+            label.set_color(color)
+            label.set_weight('bold')
     
     # changing plot position
     pos_old = ax.get_position()
@@ -147,7 +147,7 @@ def customPlot(**kwargs):
     # modifying x axis (here is assumed, that len(data) > 1)
     step_size = (x_list[-1]-x_list[0])/10.
     x_tick_list = np.arange(x_list[0], x_list[-1], step_size)
-    ax.set_xlim([x_tick_list[0]-step_size*0.8,x_tick_list[-1]+step_size*0.8])
+    ax.set_xlim([x_tick_list[0]-step_size,x_tick_list[-1]+step_size])
     ax.set_xticks(x_tick_list)
     if custom_plot_dict["x_is_time"]:
         x_ticklabel_list = [time.asctime(time.gmtime(t)) for t in x_tick_list]

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -33,6 +33,10 @@ from hf.module.database import hf_runs
 def getCustomPlotUrl():
     return "/plot/custom/"
 
+def __getCustomPlotTemplatePath(module_instance_name):
+    return os.path.join(hf.hf_dir, hf.config.get("paths", "customplot_template_dir"), module_instance_name,"_template")
+
+
 def customPlot(category_list, **kwargs):
     
     import matplotlib.pyplot as plt
@@ -40,7 +44,9 @@ def customPlot(category_list, **kwargs):
     ylabel_list = ["other", "error", "warning", "ok"]
     color_list = ["gray", "red", "orange", "green"]
     fig, ax = plt.subplots()
-    
+    template = __getCustomPlotTemplatePath(kwargs["module_instance_name"])
+    __import__(template)
+    ax.set_title(custom_plot_dict["title"])
     for color, statusnumber in zip(color_list, np.arange(1,5)):
         ax.axhline(y=statusnumber, color=color, linewidth=8)
     

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -18,7 +18,6 @@ import hf
 import re
 import cherrypy as cp
 import StringIO
-import logging
 import time
 import os
 import sys
@@ -31,9 +30,54 @@ def getCustomPlotUrl():
     return "/plot/custom/img/"
 
 def __getCustomPlotTemplateDict(module_instance_name):
+    """
+    This function retrieves a dictionary from the configuration template stored for corresponding module.
+    Dictionary's name should be "custom_plot_dict".
 
-    logger = logging.getLogger(__name__ + "__getCustomPlotTemplateDict")
-    
+    Keys used in the dictionary:
+
+    title: Title of the plot, where placeholders can be used. These should be enclosed by the following marker: [@]
+           The placeholders should match exactly the names of the keyword arguments used in the corresponding
+           module.
+    additional_hlines: Defines additional horizontal lines, which can be added to the plot. This keyword has
+                       a list of dictionaries as value. Syntax of one of these dictionaries:
+                       {"y_value" : your_y_value, "color" : your_color, "linewidth" : your_linewidth}
+                       All values in the dictionary are in matplotlib syntax.
+    custom_y_ticks: Can be used to customize the ticks of y-axis. This keyword has a list of dictionaries as value.
+                    Syntax of one of these dictionaries:
+                    {"y_value" : your_y_value, "color" : your_color, "y_tick_label" : your_y_tick_label}
+                    All values in the dictionary are in matplotlib syntax. "y_value" defines where the corresponding
+                    "y_tick_label" should be placed.
+    plot_position_changes: Can be used to adjust the position of the plot itself in the canvas with respect to the 
+                           old position chosen by matplotlib. This keyword has a dictionary as value.
+                           Syntax of this dictionary:
+                           {"x0_shift" : your_x0_shift, "y0_shift" : your_y0_shift,
+                           "x_width_change" : your_x_width_change, "y_height_change" : your_y_height_change}
+    curve_style: Defines the style of the plotted curve. This keyword has a dictionary as value.
+                 Syntax of this dictionary:
+                 {"color" : your_color, "marker" : your_marker, "linestyle" : "your_linestyle}
+                 All values in the dictionary are in matplotlib syntax.
+    x_is_time: If you use time for x-axis data in time format, an additional formatting on the ticks is applied.
+               Possible values: True, False.
+    y_lims: Here the lower and upper limit of the y-axis can be chosen. If so, this should be a list with two elements.
+    x_label: Label chosen for x-axis.
+    y_label: Label chosen for y-axis.
+
+    Minimal example of such a dictionary template you can start from:
+
+    custom_plot_dict = {}
+
+    custom_plot_dict["title"] = ""
+    custom_plot_dict["additional_hlines"] = []
+    custom_plot_dict["custom_y_ticks"] = []
+    custom_plot_dict["plot_position_changes"] = {"x0_shift":0.,"y0_shift": 0., "x_width_change": 0., "y_height_change": 0.}
+    custom_plot_dict["curve_style"] = {"color" : "white", "marker" : "o", "linestyle" : "None"}
+    custom_plot_dict["x_is_time"] = False
+    custom_plot_dict["x_label"] = ""
+    custom_plot_dict["y_label"] = ""
+
+    Please use this example to avoid 'KeyError' from an empty dictionary.
+    """
     if not hf.module.config.has_section(module_instance_name):
         raise Exception("No such module")
 
@@ -42,28 +86,35 @@ def __getCustomPlotTemplateDict(module_instance_name):
     sys.path.append(template_dir)
     try:
         template = importlib.import_module(template_name)
-    except ImportError, e:
+    except ImportError:
         raise Exception("No such plot template")
     return template.custom_plot_dict
 
 def __getDataPoints(module_instance_name,subtable_name,x_name,y_name,quantity_column_name,chosen_quantity_name,run_id):
+    """
+    This function retrieves data from the database. It accepts for now the following format of the data:
 
-    logger = logging.getLogger(__name__ + "__getDataPoints")
+    Data must be saved in a subtable of the corresponding module. This subtable should contain columns:
 
+    1) Data for the x axis (as a list).
+    2) Data for the y axis (as a list).
+    3) Quantity names, which give the y value a meaning (as a list).
+
+    In that way, multiple y-quantities depending on one x-quantity can be stored and chosen for plotting.
+    """
     if not hf.module.config.has_section(module_instance_name):
         raise Exception("No such module")
 
     module_class = hf.module.getModuleClass(hf.module.config.get(module_instance_name, "module"))
     try:
         subtable = module_class.subtables[subtable_name]
-    except IndexError, e:
+    except IndexError:
         raise Exception("No such subtable")
 
     x_column = [col for col in subtable.columns if col.name == x_name][0]
     y_column = [col for col in subtable.columns if col.name == y_name][0]
-    quantity_column = [col for col in subtable.columns if col.name == quantity_column_name][0]
 
-    data_point_columns = [quantity_column,x_column,y_column]
+    data_point_columns = [x_column,y_column]
     mod_table = subtable.module_class.module_table
     data_point_query = select(data_point_columns, \
         mod_table.c.instance == module_instance_name) \
@@ -72,28 +123,33 @@ def __getDataPoints(module_instance_name,subtable_name,x_name,y_name,quantity_co
         .where(getattr(subtable.c, quantity_column_name) == chosen_quantity_name)
     result = data_point_query.execute()
     source_data = result.fetchall()
+    if not source_data:
+        raise Exception("No data found for used database selection")
+    elif len(source_data) == 1:
+        raise Exception("Only one datapoint found for used database selection")
     return source_data
 
 def customPlot(**kwargs):
     """
+    This is the main function to produce the plot. For now, only one curve per plot is possible.
+    Computation of the limits and ticks for x-axis are calculated automaticaly.
+
     Necessary arguments given by keyword arguments **kwargs built by corresponding .html file:
-    
+
     module_instance_name: Name of the module instance of the .html file used. Needed to access the corresponding data
                           and configuration.
     subtable_name: Name of the subtable, where the data to be plotted is stored.
     x_name: Name of the column in the subtable, which contains data for the x-axis.
     y_name: Name of the column in the subtable, which contains data for the y-axis.
     quantity_column_name: Name of the column in the subtable, which contains the quantity names
-    defining the meaning of y values.
+                          defining the meaning of y values.
     chosen_quantity_name: Quantity specified for plotting. Chosen from the names in the column 'quantity_column_name'.
     run_id: Plotting is done only for one explicit run given by the run id. Needed to proper select data.
-    
+
     Additional arguments can be given to replace 'placeholders' in the title of the plot.
-    See '# setting and modifying title'.
-    
+    See 'setting and modifying title'.
     """
     import matplotlib.pyplot as plt
-    logger = logging.getLogger(__name__ + ".customPlot")
 
     fig, ax = plt.subplots()
 
@@ -102,13 +158,12 @@ def customPlot(**kwargs):
 
     # setting and modifying title
     title = custom_plot_dict["title"]
-    if custom_plot_dict["search_for_title_placeholders"]:
-        placeholder_list = re.findall(r"\[\@\](.*?)\[\@\]", custom_plot_dict["title"])
-        for placeholder in placeholder_list:
-            for key,value in kwargs.iteritems():
-                if key == placeholder:
-                    title = title.replace("[@]"+placeholder+"[@]",value)
-                    break
+    placeholder_list = re.findall(r"\[\@\](.*?)\[\@\]", title)
+    for placeholder in placeholder_list:
+        for key,value in kwargs.iteritems():
+            if key == placeholder:
+                title = title.replace("[@]"+placeholder+"[@]",value)
+                break
     ax.set_title(title)
 
     # adding horizontal lines if available
@@ -116,7 +171,8 @@ def customPlot(**kwargs):
         ax.axhline(y=add_hline["y_value"], color=add_hline["color"], linewidth=add_hline["linewidth"])
 
     # modifying y axis
-    ax.set_ylim(custom_plot_dict["y_lims"][0],custom_plot_dict["y_lims"][1])
+    if len(custom_plot_dict["y_lims"]) == 2:
+        ax.set_ylim(custom_plot_dict["y_lims"][0],custom_plot_dict["y_lims"][1])
     ax.set_ylabel(custom_plot_dict["y_label"])
 
     if len(custom_plot_dict["custom_y_ticks"]) > 0:
@@ -147,7 +203,7 @@ def customPlot(**kwargs):
         kwargs["quantity_column_name"],kwargs["chosen_quantity_name"],kwargs["run_id"])
     x_list = []
     y_list = []
-    for name,x,y in source_data:
+    for x,y in source_data:
         x_list.append(x)
         y_list.append(y)
     ax.plot(np.array(x_list),np.array(y_list), color=custom_plot_dict["curve_style"]["color"],

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -28,7 +28,7 @@ import sys
 import importlib
 import numpy as np
 import timeit
-from sqlalchemy.sql import select, func, or_
+from sqlalchemy.sql import select, func, or_ 
 from sqlalchemy import Integer, Float, Numeric
 from hf.module.database import hf_runs
 
@@ -65,21 +65,18 @@ def __getDataPoints(module_instance_name,subtable_name,x_name,y_name,quantity_co
     except IndexError, e:
         raise Exception("No such subtable")
     
-    x_column = col in subtable.columns if col.name == x_name
-    y_column = col in subtable.columns if col.name == y_name
-    quantity_column = col in subtable.columns if col.name == quantity_column_name
-    
+    x_column = [col for col in subtable.columns if col.name == x_name][0]
+    y_column = [col for col in subtable.columns if col.name == y_name][0]
+    quantity_column = [col for col in subtable.columns if col.name == quantity_column_name][0]
+
     data_point_columns = [quantity_column,x_column,y_column]
-    
     mod_table = subtable.module_class.module_table
     data_point_query = select(data_point_columns, \
         mod_table.c.instance == module_instance_name) \
         .where(subtable.c.parent_id == mod_table.c.id) \
         .where(mod_table.c.run_id == hf_runs.c.id) \
         .where(getattr(subtable.c, quantity_column_name) == chosen_quantity_name)
-    
-    data_point_query = data_point_query.where(or_(hf_runs.c.completed == True,
-        hf_runs.c.completed == None))
+    logger.error(data_point_query)
     result = data_point_query.execute()
     source_data = result.fetchall()
     logger.error(source_data)
@@ -98,7 +95,7 @@ def customPlot(**kwargs):
         ax.axhline(y=statusnumber, color=color, linewidth=8)
     
     __getDataPoints(kwargs["module_instance_name"],kwargs["subtable_name"],kwargs["x_name"],kwargs["y_name"],
-        kwargs["quantity_column_name",kwargs["chosen_quantity_name"])
+        kwargs["quantity_column_name"],kwargs["chosen_quantity_name"])
     
     img_data = StringIO.StringIO()
     try:

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -23,6 +23,9 @@ import traceback
 import logging
 import datetime
 import time
+import os
+import sys
+import importlib
 import numpy as np
 import timeit
 from sqlalchemy.sql import select, func, or_
@@ -33,9 +36,15 @@ from hf.module.database import hf_runs
 def getCustomPlotUrl():
     return "/plot/custom/"
 
-def __getCustomPlotTemplatePath(module_instance_name):
-    return os.path.join(hf.hf_dir, hf.config.get("paths", "customplot_template_dir"), module_instance_name,"_template")
-
+def __getCustomPlotTemplateDict(module_instance_name):
+    template_name = module_instance_name + "_template" 
+    template_dir= os.path.join(hf.hf_dir, hf.config.get("paths", "customplot_template_dir"))
+    logger = logging.getLogger(__name__ + "__getCustomPlotTemplateDict")
+    logger.error(template_dir)
+    sys.path.append(template_dir)
+    logger.error(sys.path)
+    template = importlib.import_module(template_name)
+    return template.custom_plot_dict
 
 def customPlot(category_list, **kwargs):
     
@@ -44,8 +53,7 @@ def customPlot(category_list, **kwargs):
     ylabel_list = ["other", "error", "warning", "ok"]
     color_list = ["gray", "red", "orange", "green"]
     fig, ax = plt.subplots()
-    template = __getCustomPlotTemplatePath(kwargs["module_instance_name"])
-    __import__(template)
+    custom_plot_dict = __getCustomPlotTemplateDict(kwargs["module_instance_name"])
     ax.set_title(custom_plot_dict["title"])
     for color, statusnumber in zip(color_list, np.arange(1,5)):
         ax.axhline(y=statusnumber, color=color, linewidth=8)

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -115,7 +115,7 @@ def customPlot(**kwargs):
     custom_y_tick_colors = [d["color"] for d in custom_plot_dict["custom_y_ticks"]]
     
     ax.set_yticks(custom_y_ticks)
-    ax.set_yticklabels(custom_y_labels)
+    ax.set_yticklabels(custom_y_tick_labels)
     
     tick_labels = ax.get_yticklabels()
     for color,label in zip(custom_y_tick_colors,tick_labels):
@@ -128,7 +128,7 @@ def customPlot(**kwargs):
         pos_old.x0+custom_plot_dict["plot_position_changes"]["x0_shift"],
         pos_old.y0+custom_plot_dict["plot_position_changes"]["y0_shift"],
         pos_old.width+custom_plot_dict["plot_position_changes"]["x_width_change"],
-        pos1_old.height+custom_plot_dict["plot_position_changes"]["y_height_change"]
+        pos_old.height+custom_plot_dict["plot_position_changes"]["y_height_change"]
         ])
     
     # retrieving data
@@ -137,8 +137,8 @@ def customPlot(**kwargs):
     x_list = []
     y_list = []
     for name,x,y in source_data:
-        time_list.append(x)
-        status_list.append(y)
+        x_list.append(x)
+        y_list.append(y)
     logger.error(x_list)
     ax.plot(np.array(x_list),np.array(y_list), color='white', marker='o', linestyle='None')
     
@@ -149,7 +149,7 @@ def customPlot(**kwargs):
     ax.set_xticks(x_tick_list)
     if custom_plot_dict["x_is_time"]:
         x_ticklabel_list = [time.asctime(time.gmtime(t)) for t in x_tick_list]
-        ax.set_xticklabels(time_ticklabel_list, rotation='vertical', fontsize=9)
+        ax.set_xticklabels(x_ticklabel_list, rotation='vertical', fontsize=9)
     ax.set_xlabel(custom_plot_dict["x_label"])
     
     # saving figure

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012 Institut für Experimentelle Kernphysik - Karlsruher Institut für Technologie
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import hf
+import re
+import cherrypy as cp
+import json
+import StringIO
+import traceback
+import logging
+import datetime
+import time
+import numpy as np
+import timeit
+from sqlalchemy.sql import select, func, or_
+from sqlalchemy import Integer, Float, Numeric
+from hf.module.database import hf_runs
+
+@hf.url.absoluteUrl
+def getCustomPlotUrl():
+    return "/plot/custom/"
+
+def customPlot(category_list, **kwargs):
+    
+    import matplotlib.pyplot as plt
+    logger = logging.getLogger(__name__ + ".customPlot")
+    ylabel_list = ["other", "error", "warning", "ok"]
+    color_list = ["gray", "red", "orange", "green"]
+    fig, ax = plt.subplots()
+    
+    for color, statusnumber in zip(color_list, np.arange(1,5)):
+        ax.axhline(y=statusnumber, color=color, linewidth=8)
+    
+    img_data = StringIO.StringIO()
+    return img_data
+

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -45,5 +45,10 @@ def customPlot(category_list, **kwargs):
         ax.axhline(y=statusnumber, color=color, linewidth=8)
     
     img_data = StringIO.StringIO()
-    return img_data
+    try:
+        fig.savefig(img_data, transparent=True)
+        cp.response.headers['Content-Type'] = "image/png"
+        return img_data.getvalue()
+    finally:
+        img_data.close()
 

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -17,21 +17,14 @@
 import hf
 import re
 import cherrypy as cp
-import json
 import StringIO
-import traceback
 import logging
-import datetime
 import time
 import os
 import sys
 import importlib
-from hf.module.database import hf_runs
 import numpy as np
-import timeit
-from sqlalchemy.sql import select, func, or_ 
-from sqlalchemy import Integer, Float, Numeric
-from hf.module.database import hf_runs
+from sqlalchemy.sql import select
 
 @hf.url.absoluteUrl
 def getCustomPlotUrl():
@@ -82,7 +75,23 @@ def __getDataPoints(module_instance_name,subtable_name,x_name,y_name,quantity_co
     return source_data
 
 def customPlot(**kwargs):
-
+    """
+    Necessary arguments given by keyword arguments **kwargs built by corresponding .html file:
+    
+    module_instance_name: Name of the module instance of the .html file used. Needed to access the corresponding data
+                          and configuration.
+    subtable_name: Name of the subtable, where the data to be plotted is stored.
+    x_name: Name of the column in the subtable, which contains data for the x-axis.
+    y_name: Name of the column in the subtable, which contains data for the y-axis.
+    quantity_column_name: Name of the column in the subtable, which contains the quantity names
+    defining the meaning of y values.
+    chosen_quantity_name: Quantity specified for plotting. Chosen from the names in the column 'quantity_column_name'.
+    run_id: Plotting is done only for one explicit run given by the run id. Needed to proper select data.
+    
+    Additional arguments can be given to replace 'placeholders' in the title of the plot.
+    See '# setting and modifying title'.
+    
+    """
     import matplotlib.pyplot as plt
     logger = logging.getLogger(__name__ + ".customPlot")
 

--- a/hf/plotgenerator/customplot.py
+++ b/hf/plotgenerator/customplot.py
@@ -100,7 +100,15 @@ def customPlot(**kwargs):
     custom_plot_dict = __getCustomPlotTemplateDict(kwargs["module_instance_name"])
     
     # setting and modifying title
-    ax.set_title(custom_plot_dict["title"])
+    title = custom_plot_dict["title"]
+    if custom_plot_dict["search_for_title_placeholders"]:
+        placeholder_list = re.findall(r"\[\@\](.*?)\[\@\]", custom_plot_dict["title"])
+        for placeholder in placeholder_list:
+            for key,value in kwargs.interitems():
+                if key == placeholder:
+                    title = title.replace("[@]"+placeholder+"[@]",value)
+                    break
+    ax.set_title(title)
     
     # adding horizontal lines if available
     for add_hline in custom_plot_dict["additional_hlines"]:

--- a/hf/plotgenerator/dispatcher.py
+++ b/hf/plotgenerator/dispatcher.py
@@ -55,9 +55,9 @@ class Dispatcher(object):
         if img == "img":
             if plt_type == "time":
                 return hf.plotgenerator.timeseriesPlot(self.category_list, **kwargs)
-        else:
-            if plt_type == "custom":
+            elif plt_type == "custom":
                 return hf.plotgenerator.customPlot(**kwargs)
+        else:
             try:
                 # just get the lastest run, we don't really need it
                 run = hf_runs.select(). \

--- a/hf/plotgenerator/dispatcher.py
+++ b/hf/plotgenerator/dispatcher.py
@@ -57,7 +57,7 @@ class Dispatcher(object):
                 return hf.plotgenerator.timeseriesPlot(self.category_list, **kwargs)
         else:
             if plt_type == "custom":
-                return hf.plotgenerator.customPlot(self.category_list, **kwargs)
+                return hf.plotgenerator.customPlot(**kwargs)
             try:
                 # just get the lastest run, we don't really need it
                 run = hf_runs.select(). \

--- a/hf/plotgenerator/dispatcher.py
+++ b/hf/plotgenerator/dispatcher.py
@@ -56,6 +56,8 @@ class Dispatcher(object):
             if plt_type == "time":
                 return hf.plotgenerator.timeseriesPlot(self.category_list, **kwargs)
         else:
+            if plt_type == "custom":
+                return hf.plotgenerator.customPlot(self.category_list, **kwargs)
             try:
                 # just get the lastest run, we don't really need it
                 run = hf_runs.select(). \


### PR DESCRIPTION
I've extended the plotgenerator to be able to produce customized plots on demand.

The plotting function customPlot(**kwargs) uses a plot template saved as a dictionary for a each module instance using it. Such templates are saved in the customplot_templates folder for now (please check, whether this is ok or should be moved to HappaFaceModules repository).

This extension should be able to plot one curve for given data (x,y datapoints). See documentation in customplot.py file for more information. This is not a very general use case but can be easily extended to more complicated ones. So if you have any suggestions for extensions of the code, please share them :)
The aim was to start with something very simple and extend it step by step.

You can try the new plotgenerator out on my instance:

http://ekphappyface.physik.uni-karlsruhe.de/HappyFace/art_test/category/batch