### PR TITLE
optional remote archive location

### DIFF
--- a/defaultconfig/happyface.cfg
+++ b/defaultconfig/happyface.cfg
@@ -4,6 +4,8 @@ happyface_url = /
 
 static_dir = static
 archive_dir = %(static_dir)s/archive
+# optional location to SCP archive downloads to (e.g. user@machine:~/HappyFace/static/archive)
+remote_archive_dir = 
 
 # Note: By default, the temporary directory is "world readable"
 #       via HTTP, which is maybe not what you want. Change to an


### PR DESCRIPTION
any files copied to the archive directory are additionally SCP'ed to that location

Use case: We want to run acquire on a machine with an active voms proxy (M1). A second machine hosts the web server (M2). The database is also running on M2. Now M1 acquires everything, SCP's all the plots (or whatever is handled with `copyToArchive()`) to M2 and then writes to the database on M2.